### PR TITLE
Removing unnecessary bits from meeting minutes template

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting_minutes.md
+++ b/.github/ISSUE_TEMPLATE/meeting_minutes.md
@@ -13,13 +13,6 @@ YYYYMMDD - time
 - Register for future meetings: https://zoom-lfx.platform.linuxfoundation.org/meeting/94448504669?password=eae95588-ef7e-4d50-a03b-7e8c64fb14d0&invite=true
 - Subscribe to mailing list: Send an email to [distinguished-engineer-community+subscribe@lists.finos.org](mailto:distinguished-engineer-community+subscribe@lists.finos.org) or view mailing list https://lists.finos.org/g/distinguished-engineer-community
 
-## Tracking attendance
-Please comment on this issue with your name and affiliation to help track attendence. If you are unable to comment on a GitHub issue, please let the chair know to add you to the list below:
-
-### Untracked attendees
-- Fullname, Affiliation, (optional) GitHub username
-- ...
-
 ## Meeting notices
 - FINOS **Project leads** are responsible for observing the FINOS guidelines for [running project meetings](https://community.finos.org/docs/governance/meeting-procedures/). Project maintainers can find additional resources in the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
 
@@ -39,10 +32,8 @@ Please comment on this issue with your name and affiliation to help track attend
 - [ ] ...
 - [ ] AOB, Q&A & Adjourn (5mins)
 
-## Decisions Made
-- [ ] Decision 1
-- [ ] Decision 2
-- [ ] ...
+## Meeting minutes
+- ...
 
 ## Action Items
 - [ ] Action 1


### PR DESCRIPTION
## Description

Removing a few unnecessary bits from the meeting minutes template - attendee tracking is done by teh LFX meeting system now, so there's no need to include a section for it in the minutes issue template.

## Change Tier

<!-- Select one. If unsure, start with Standard — any maintainer can escalate. -->

- [x] **Standard** — new content, fixes, or improvements
- [ ] **Significant** — governance, structural, or directional change (requires prior discussion issue labelled `significant-decision` open for ≥10 business days)

## Working Group

<!-- Delete those that don't apply. -->

- [ ] Outreach
- [ ] Inclusive Engineering
- [ ] DE Role Definition
- [x] Cross‑cutting / general

## Checklist

- [x] I have read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)
- [x] All commits are signed off (`git commit -s`) per the DCO
- [x] Content is vendor‑ and org‑agnostic
- [x] Images have alt text; new files follow naming conventions
